### PR TITLE
Fix use of default spirv_cross to SPIRV_CROSS_NAMESPACE in spirv_hlsl…

### DIFF
--- a/spirv_hlsl.cpp
+++ b/spirv_hlsl.cpp
@@ -3029,7 +3029,7 @@ string CompilerHLSL::get_inner_entry_point_name() const
 		SPIRV_CROSS_THROW("Unsupported execution model.");
 }
 
-uint32_t CompilerHLSL::input_vertices_from_execution_mode(spirv_cross::SPIREntryPoint &execution) const
+uint32_t CompilerHLSL::input_vertices_from_execution_mode(SPIRV_CROSS_NAMESPACE::SPIREntryPoint &execution) const
 {
 	uint32_t input_vertices = 1;
 


### PR DESCRIPTION
….cpp

Change use of default namespace spirv_cross to configurable SPIRV_CROSS_NAMESPACE because sometimes it matters. E.g. in Diligent Engine it is redefined as SPIRV_CROSS_NAMESPACE=diligent_spirv_cross so this line won't compile until we change vanilla namespace to configurable macro.

No other changes that can potentially make functional differences, all tests pass.